### PR TITLE
JS-1603 Configure Renovate to avoid grouped updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,13 @@
   },
   "packageRules": [
     {
+      "description": "Don't group updates by default",
+      "matchPackageNames": ["*"],
+      "groupName": null
+    },
+    {
       "matchManagers": ["github-actions"],
-      "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "pinDigests": false
     },
     {
       "matchManagers": ["github-actions"],
@@ -24,5 +27,6 @@
     }
   ],
   "autoApprove": true,
+  "prCreation": "immediate",
   "rebaseWhen": "never"
 }


### PR DESCRIPTION
### Summary
- align Renovate behavior with sonar-flex commit eae1e601a76abe7e117b541f85af7f5c0d6112e4
- disable default grouping by setting groupName to 
ull for all packages
- remove explicit GitHub Actions grouping
- set prCreation to immediate so updates are opened without batching delays

This keeps updates flowing per package age instead of waiting for grouped batches.