### PR TITLE
CLP-91 Update notifications Slack channels

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: core-languages-releases
+          slack-channel: squad-corelang-releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,4 @@ jobs:
     with:
       version: ${{ inputs.version }}
       publishToBinaries: true
-      slackChannel:  squad-web
+      slackChannel: core-languages-releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,4 @@ jobs:
     with:
       version: ${{ inputs.version }}
       publishToBinaries: true
-      slackChannel: core-languages-releases
+      slackChannel: squad-corelang-releases


### PR DESCRIPTION
Part of [CLP-59](https://sonarsource.atlassian.net/browse/CLP-59).

----
## Summary by Gitar

- **Workflow updates:**
  - Changed the `slackChannel` in `.github/workflows/release.yml` from `squad-web` to `core-languages-releases`.

<sub>This will update automatically on new commits.</sub>

[CLP-59]: https://sonarsource.atlassian.net/browse/CLP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ