### PR TITLE
JS-852 Use squad Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,17 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>SonarSource/renovate-config:languages-team"],
+  "extends": ["local>SonarSource/core-languages-tooling-public:renovate-config"],
   "configMigration": true,
+  "addLabels": ["dependencies"],
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": ["github-actions", "maven"],
   "dockerfile": {
     "enabled": true
   },
   "packageRules": [
-    {
-      "description": "Don't group updates by default",
-      "matchPackageNames": ["*"],
-      "groupName": null
-    },
     {
       "matchManagers": ["github-actions"],
       "pinDigests": false
@@ -27,6 +24,5 @@
     }
   ],
   "autoApprove": true,
-  "prCreation": "immediate",
-  "rebaseWhen": "never"
+  "prCreation": "immediate"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:languages-tooling"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
   "enabledManagers": [
     "github-actions",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,28 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>SonarSource/core-languages-tooling-public:renovate-config"],
-  "configMigration": true,
-  "addLabels": ["dependencies"],
-  "minimumReleaseAgeBehaviour": "timestamp-required",
-  "enabledManagers": ["github-actions", "maven"],
+  "extends": [
+    "local>SonarSource/core-languages-tooling-public:languages-tooling"
+  ],
+  "enabledManagers": [
+    "github-actions",
+    "maven"
+  ],
   "dockerfile": {
     "enabled": true
   },
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "pinDigests": false
     },
     {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["pin", "rollback"],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "pin",
+        "rollback"
+      ],
       "enabled": false
-    },
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/"
     }
-  ],
-  "autoApprove": true,
-  "prCreation": "immediate"
+  ]
 }


### PR DESCRIPTION
## Summary
- switch this repository to the squad Renovate preset
- keep only repo-specific Renovate behavior in the repository

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- minimumReleaseAgeBehaviour: timestamp-required -> timestamp-optional
- configMigration: true -> unset
- autoApprove: true -> unset
- packageRules removed: {"matchManagers":["regex"],"versioning":"regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"}; minor/patch for !/^0/
- regexManagers: 1 -> 0
<!-- codex-effective-delta:end -->
