### PR TITLE
CLP-135 Clean up Renovate config in nodejs-maven-plugin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,13 +3,6 @@
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
-  "enabledManagers": [
-    "github-actions",
-    "maven"
-  ],
-  "dockerfile": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "matchManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,23 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "pinDigests": false
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "pin",
-        "rollback"
-      ],
-      "enabled": false
-    }
   ]
 }


### PR DESCRIPTION
Part of CLP-11.

This PR cleans up the local Renovate config after the latest updates in the squad parent preset.

Expected current effective delta:
- track `mise.toml` updates
- pin third-party GitHub Actions to commit SHAs
- allow rollback PRs for third-party GitHub Actions
